### PR TITLE
Quick fix for the board display bug

### DIFF
--- a/public/css/chess.css
+++ b/public/css/chess.css
@@ -5,6 +5,7 @@
     border: 2px solid #333;
     display: grid;
     grid-template-columns: repeat(8, 1fr);
+    padding: 0;
   }
   #game-ct > li {
     list-style-type: none;


### PR DESCRIPTION
# Changes
- The CSS was not working properly, so fixed the rendering of board such that there is no left space in the board.

# Before
![image](https://github.com/user-attachments/assets/8c5ddf38-bb49-42a4-8fe0-30dce445c1c4)

# After
![image](https://github.com/user-attachments/assets/147ae88b-8575-4a6a-9115-0f4e337ade05)
