### PR TITLE
Updated CSS for new options in the game

### DIFF
--- a/public/css/chess.css
+++ b/public/css/chess.css
@@ -21,6 +21,7 @@
     width: 100%;
     height: 50px;
     list-style-type: none;
+    position: relative;
   }
   #game-ct li:nth-child(odd) li:nth-child(even),
   #game-ct li:nth-child(even) li:nth-child(odd) {
@@ -90,6 +91,7 @@
 }
 
 .piece {
+    position: relative;
     width: 100%;
     height: 100%;
 }
@@ -98,12 +100,13 @@
     box-shadow: 0 0 10px 3px rgba(0, 255, 0, 0.7);
     transform: scale(1.1);
     transition: all 0.3s ease;
-    z-index: 10;
+    z-index: 400000;
 }
 
 .piece.selected::after {
     content: '';
     position: absolute;
+    z-index: 400000;
     top: -5px;
     left: -5px;
     right: -5px;
@@ -113,4 +116,36 @@
     pointer-events: none;
 }
 
+#game-ct:has(.piece.selected) li li:not(:has(.piece.selected), .destination-cell) {
+    filter: brightness(0.5);
+    z-index: 1;
+}
 
+#game-ct:has(.piece.selected) li li.destination-cell {
+    filter: brightness(1);
+    z-index: 2;
+}
+
+#game-ct:has(.piece.selected) li li.destination-cell:has(.piece)::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #F00;
+    pointer-events: none;
+}
+
+#game-ct:has(.piece.selected) li li.destination-cell::before {
+    content: '';
+    position: absolute;
+    --gap: 15px;
+    top: var(--gap);
+    left: var(--gap);
+    right: var(--gap);
+    bottom: var(--gap);
+    border-radius: 100rem;
+    background: #0006;
+    pointer-events: none;
+}


### PR DESCRIPTION
# Purpose of this PR
> This is not a functional update; this update only adds more options for styling in future...
- Added styling support for a new game feature, "Destination Cells"
- Darkening of all cells when some piece is selected
- Support for specific highlighting tiles

# Glimpse
![image](https://github.com/user-attachments/assets/7d40c455-f340-4011-b60f-8b4b3e0baa38)

# How to access this styling?
- Selected piece logic and darkening logic don't need any other modifications
- To highlight a cell that is expected to be a destination for some given piece, add class `destination-cell` to the cell.

# Note
**DO NOT MERGE THIS PR UNLESS FUTURE SCOPE HAS THIS FEATURE**